### PR TITLE
Refactoring

### DIFF
--- a/tests/main.rs
+++ b/tests/main.rs
@@ -6,9 +6,6 @@ fn main() {
 	let (a, b) = (random!(u64), random!(u64));
 	assert_ne!(a, b);
 
-	assert_eq!(obfstr!("Hello world"), "Hello world");
-	assert_eq!("Hello world", obfconst!("Hello world"));
-
 	assert_eq!(
 		obfstr!("This literal is very very very long to see if it correctly handles long string"),
 		        "This literal is very very very long to see if it correctly handles long string");
@@ -19,6 +16,6 @@ fn main() {
 	assert_eq!(obfstr!(L"ABC"), &[b'A' as u16, b'B' as u16, b'C' as u16]);
 	assert_eq!(obfstr!(L"🌍"), &[0xd83c, 0xdf0d]);
 
-	assert_eq!(wide!("ABC"), obfconst!(L"ABC"));
-	assert_eq!(wide!("🌍"), obfconst!(L"🌍"));
+	assert!(obfeq!(wide!("ABC"), L"ABC"));
+	assert!(obfeq!(wide!("🌍"), L"🌍"));
 }


### PR DESCRIPTION
* Removed type inferred compiletime random
* Added optional explicit seed to compiletime random
* Changed entropy to make better use of the low bits
* Removed PartialEq implementation in favor of obfeq macro
* Added obfeq macro to check equality with obfuscated string
* Changed as_slice methods to const fn