### PR TITLE
Remove RUSTC_BOOTSTRAP hack

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,0 @@
-fn main() {
-	// Please I need to be generic over _all_ arrays._.;
-	println!("cargo:rustc-env=RUSTC_BOOTSTRAP=1");
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ Compiletime string literal obfuscation.
 // Reexport these because reasons...
 #[doc(hidden)]
 pub use obfstr_impl::*;
+pub use obfstr_impl::wide;
 
 #[cfg(feature = "rand")]
 pub use cfgd::*;
@@ -14,6 +15,7 @@ pub use cfgd::*;
 mod cfgd {
 
 use core::{char, fmt, mem, ops, ptr, slice, str};
+pub use obfstr_impl::random;
 
 /// Compiletime string literal obfuscation, returns a borrowed temporary and may not escape the statement it was used in.
 ///
@@ -90,25 +92,6 @@ macro_rules! unsafe_obfstr {
 		#[$crate::obfstr_attribute]
 		const S: $crate::ObfString<[u8; _strlen_!($string)]> = $crate::ObfString::new(_obfstr_!($string));
 		S.decrypt($crate::random!(usize) & 0xffff).unsafe_as_static_str()
-	}};
-}
-
-/// Compiletime random number generator.
-///
-/// Every time the code is compiled, a new random number literal is generated.
-/// Recompilation (and thus regeneration of the number) is not triggered automatically.
-///
-/// Supported types are `u8`, `u16`, `u32`, `u64`, `usize`, `i8`, `i16`, `i32`, `i64`, `isize`, `bool`, `f32` and `f64`.
-///
-/// ```
-/// const RND: i32 = obfstr::random!(u8) as i32;
-/// assert!(RND >= 0 && RND <= 255);
-/// ```
-#[macro_export]
-macro_rules! random {
-	($ty:ident) => {{
-		#[$crate::random_attribute]
-		const N: $ty = _random_!($ty); N
 	}};
 }
 
@@ -326,20 +309,4 @@ impl<A: AsRef<[u16]>> fmt::Display for WObfBuffer<A> {
 		Ok(())
 	}
 }
-}
-
-/// Wide string literal, returns an array of words.
-///
-/// The type of the returned literal is `&'static [u16; LEN]`.
-///
-/// ```
-/// let expected = &['W' as u16, 'i' as u16, 'd' as u16, 'e' as u16];
-/// assert_eq!(obfstr::wide!("Wide"), expected);
-/// ```
-#[macro_export]
-macro_rules! wide {
-	($s:literal) => {{
-		#[$crate::wide_attribute]
-		const W: &[u16] = _wide_!($s); W
-	}};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,14 +132,14 @@ impl<A: AsRef<[u8]> + AsMut<[u8]> + Clone> ObfString<A> {
 	/// It is used to obfuscate the underlying call to the decrypt routine.
 	#[inline(always)]
 	pub fn decrypt(&self, x: usize) -> ObfBuffer<A> {
+		let mut buffer = self.data.clone();
+		let data = self.data.as_ref();
+		let src = data.as_ptr() as usize - data.len() * XREF_SHIFT;
 		unsafe {
-			let mut buffer = self.data.clone();
-			let data = self.data.as_ref();
-			let src = data.as_ptr() as usize - data.len() * XREF_SHIFT;
 			let f: unsafe fn(&mut [u8], usize) = mem::transmute(ptr::read_volatile(&(decryptbuf as usize + x)) - x);
 			f(buffer.as_mut(), src);
-			ObfBuffer(buffer)
 		}
+		ObfBuffer(buffer)
 	}
 }
 impl<A: AsRef<[u8]> + AsMut<[u8]> + Clone> fmt::Debug for ObfString<A> {
@@ -230,14 +230,14 @@ impl<A: AsRef<[u16]> + AsMut<[u16]> + Clone> WObfString<A> {
 	/// It is used to obfuscate the underlying call to the decrypt routine.
 	#[inline(always)]
 	pub fn decrypt(&self, x: usize) -> WObfBuffer<A> {
+		let mut buffer = self.data.clone();
+		let data = self.data.as_ref();
+		let src = data.as_ptr() as usize - data.len() * XREF_SHIFT;
 		unsafe {
-			let mut buffer = self.data.clone();
-			let data = self.data.as_ref();
-			let src = data.as_ptr() as usize - data.len() * XREF_SHIFT;
 			let f: unsafe fn(&mut [u16], usize) = mem::transmute(ptr::read_volatile(&(wdecryptbuf as usize + x)) - x);
 			f(buffer.as_mut(), src);
-			WObfBuffer(buffer)
 		}
+		WObfBuffer(buffer)
 	}
 }
 impl<A: AsRef<[u16]> + AsMut<[u16]> + Clone> fmt::Debug for WObfString<A> {


### PR DESCRIPTION
Recently Rust semi-stabilized `min_const_generics` for `AsRef`, `AsMut` and others.
Using these two traits are enough to implement this crate on fully stable Rust.

I'll make a separate PR to prepare publishing of the crates.

Fixes #17 #22