### PR TITLE
Position API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obfstr"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2018"
 license = "MIT"
 


### PR DESCRIPTION
The position API is a compiletime function finding the position of a substring (needle) in a larger string (haystack).
Its use case is pooling string literals together in a single obfstr instance where the original string can be sliced given its position in the larger pool.