### PR TITLE
Code Cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obfstr"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2018"
 license = "MIT"
 
@@ -11,6 +11,3 @@ repository = "https://github.com/CasualX/obfstr"
 readme = "readme.md"
 keywords = ["obfuscation", "hash", "random", "wide"]
 categories = ["no-std"]
-
-[features]
-unsafe_static_str = []

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -1,0 +1,82 @@
+use core::ptr;
+
+/// Obfuscates the xref to static data.
+///
+/// ```
+/// static FOO: i32 = 42;
+/// let foo = obfstr::xref!(&FOO);
+///
+/// // When looking at the disassembly the reference to `FOO` has been obfuscated.
+/// assert_eq!(foo as *const _, &FOO as *const _);
+/// ```
+#[macro_export]
+macro_rules! xref {
+	($e:expr) => { $crate::xref($e, $crate::random!(usize) & 0xffff) };
+}
+
+/// Obfuscates the xref to static data.
+///
+/// The offset can be initialized with [`random!`] for a compiletime random value.
+///
+/// ```
+/// static FOO: i32 = 42;
+/// let foo = obfstr::xref(&FOO, 0x123);
+///
+/// // When looking at the disassembly the reference to `FOO` has been obfuscated.
+/// assert_eq!(foo as *const _, &FOO as *const _);
+/// ```
+#[inline(always)]
+pub fn xref<T: ?Sized>(p: &'static T, offset: usize) -> &'static T {
+	unsafe {
+		let mut p: *const T = p;
+		// To avoid LLMV optimizing away the obfuscation, launder it through read_volatile
+		let val = ptr::read_volatile(&(p as *const u8).wrapping_sub(offset)).wrapping_add(offset);
+		// set_ptr_value
+		*(&mut p as *mut *const T as *mut *const u8) = val;
+		&*p
+	}
+}
+
+/// Obfuscates the xref to static data.
+///
+/// ```
+/// static mut FOO: i32 = 42;
+/// let foo = obfstr::xref_mut!(unsafe { &mut FOO });
+///
+/// // When looking at the disassembly the reference to `FOO` has been obfuscated.
+/// assert_eq!(foo as *mut _, unsafe { &mut FOO } as *mut _);
+/// ```
+#[macro_export]
+macro_rules! xref_mut {
+	($e:expr) => { $crate::xref_mut($e, $crate::random!(usize) & 0xffff) };
+}
+
+/// Obfuscates the xref to static data.
+///
+/// The offset can be initialized with [`random!`] for a compiletime random value.
+///
+/// ```
+/// static mut FOO: i32 = 42;
+/// let foo = obfstr::xref_mut(unsafe { &mut FOO }, 0x321);
+///
+/// // When looking at the disassembly the reference to `FOO` has been obfuscated.
+/// assert_eq!(foo as *mut _, unsafe { &mut FOO } as *mut _);
+/// ```
+#[inline(always)]
+pub fn xref_mut<T: ?Sized>(p: &'static mut T, offset: usize) -> &'static mut T {
+	unsafe {
+		let mut p: *mut T = p;
+		// To avoid LLMV optimizing away the obfuscation, launder it through read_volatile
+		let val = ptr::read_volatile(&(p as *mut u8).wrapping_sub(offset)).wrapping_add(offset);
+		// set_ptr_value
+		*(&mut p as *mut *mut T as *mut *mut u8) = val;
+		&mut *p
+	}
+}
+
+#[test]
+fn test_xref_slice() {
+	static FOO: [i32; 42] = [13; 42];
+	let foo = xref::<[i32]>(&FOO[..], 0x1000);
+	assert_eq!(foo as *const _, &FOO as *const _);
+}


### PR DESCRIPTION
Includes breaking changes:

* Remove `obflocal`, `obfconst`, `obfeq`, `ObfString`, `ObfBuffer`
* Change `hash` to DJB2 to xor variation
* Move xref to its own module
* Remove `static mut` to just `static` hopefully the xref breaking keeps IDA at bay
  The problem with `static mut` is that it makes it hard to protect against malicious modification