### PR TITLE
Fix typo and simplify entropy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obfstr"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -93,12 +93,12 @@ macro_rules! __obfbytes {
 	($s:expr) => {{
 		const _OBFBYTES_STRING: &[u8] = $s;
 		const _OBFBYTES_LEN: usize = _OBFBYTES_STRING.len();
-		const _OBFBYTES_KEYSTREAM: [u8; _OBFBYTES_LEN] = $crate::bytes::keystream::<_OBFBYTES_LEN>($crate::random!(u32, "key", stringify!($e)));
+		const _OBFBYTES_KEYSTREAM: [u8; _OBFBYTES_LEN] = $crate::bytes::keystream::<_OBFBYTES_LEN>($crate::__entropy!("key", stringify!($s)) as u32);
 		static _OBFBYTES_SDATA: [u8; _OBFBYTES_LEN] = $crate::bytes::obfuscate::<_OBFBYTES_LEN>(_OBFBYTES_STRING, &_OBFBYTES_KEYSTREAM);
 		$crate::bytes::deobfuscate::<_OBFBYTES_LEN>(
 			$crate::__xref!(
-				$crate::random!(usize, "offset", stringify!($e)),
-				$crate::random!(u64, "xref", stringify!($e)),
+				$crate::__entropy!("offset", stringify!($s)) as usize,
+				$crate::__entropy!("xref", stringify!($s)),
 				&_OBFBYTES_SDATA),
 			&_OBFBYTES_KEYSTREAM)
 	}};

--- a/src/cfo.rs
+++ b/src/cfo.rs
@@ -46,7 +46,7 @@ pub const fn generate<const LEN: usize>(mut key: u32, mut xor: u32, stmts: &[&'s
 macro_rules! obfstmt {
 	($($stmt:stmt;)*) => {{
 		// Initial KEY and XOR values
-		const _OBFSTMT_KEY: u32 = $crate::random!(u32);
+		const _OBFSTMT_KEY: u32 = $crate::__entropy!(stringify!($($stmt;)*)) as u32;
 		const _OBFSTMT_XOR: u32 = $crate::murmur3(b"XOR", _OBFSTMT_KEY);
 		// Count the number of statements
 		const _OBFSTMT_LEN: usize = <[&'static str]>::len(&[$(stringify!($stmt)),*]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,11 +147,20 @@ macro_rules! hash {
 	($s:expr) => {{ const _DJB2_HASH: u32 = $crate::hash($s); _DJB2_HASH }};
 }
 
-/// Produces pseudorandom entropy given the file, line and column information.
+/// Produces pseudorandom entropy from the given string.
 #[doc(hidden)]
 #[inline(always)]
 pub const fn entropy(string: &str) -> u64 {
 	splitmix(SEED ^ splitmix(hash(string) as u64))
+}
+
+/// Produces pseudorandom entropy from the argument literals.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __entropy {
+	($($seeds:expr),* $(,)?) => {
+		$crate::entropy(concat!(file!(), ":", line!(), ":", column!() $(, ":", $seeds)*))
+	};
 }
 
 /// Compiletime RNG seed.

--- a/src/words.rs
+++ b/src/words.rs
@@ -29,12 +29,12 @@ macro_rules! __obfwide {
 	($s:expr) => {{
 		const _OBFWIDE_STRING: &[u16] = $crate::wide!($s);
 		const _OBFWIDE_LEN: usize = _OBFWIDE_STRING.len();
-		const _OBFWIDE_KEYSTREAM: [u16; _OBFWIDE_LEN] = $crate::words::keystream::<_OBFWIDE_LEN>($crate::random!(u32, "key", stringify!($e)));
+		const _OBFWIDE_KEYSTREAM: [u16; _OBFWIDE_LEN] = $crate::words::keystream::<_OBFWIDE_LEN>($crate::__entropy!("key", stringify!($s)) as u32);
 		static _OBFWIDE_SDATA: [u16; _OBFWIDE_LEN] = $crate::words::obfuscate::<_OBFWIDE_LEN>(_OBFWIDE_STRING, &_OBFWIDE_KEYSTREAM);
 		$crate::words::deobfuscate::<_OBFWIDE_LEN>(
 			$crate::__xref!(
-				$crate::random!(usize, "offset", stringify!($e)),
-				$crate::random!(u64, "xref", stringify!($e)),
+				$crate::__entropy!("offset", stringify!($s)) as usize,
+				$crate::__entropy!("xref", stringify!($s)),
 				&_OBFWIDE_SDATA),
 			&_OBFWIDE_KEYSTREAM)
 	}};

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -12,7 +12,7 @@ use core::{hint, ptr};
 #[macro_export]
 macro_rules! xref {
 	($e:expr) => {
-		$crate::__xref!($crate::random!(usize, stringify!($e), 1), $crate::random!(u64, stringify!($e), 2), $e)
+		$crate::__xref!($crate::__entropy!(stringify!($e), 1) as usize, $crate::__entropy!(stringify!($e), 2), $e)
 	};
 }
 #[doc(hidden)]
@@ -84,7 +84,7 @@ pub fn xref<T: ?Sized, const OFFSET: usize, const SEED: u64>(p: &'static T, offs
 /// ```
 #[macro_export]
 macro_rules! xref_mut {
-	($e:expr) => { $crate::__xref_mut!($crate::random!(usize, stringify!($e), 1), $crate::random!(u64, stringify!($e), 2), $e) };
+	($e:expr) => { $crate::__xref_mut!($crate::__entropy!(stringify!($e), 1) as usize, $crate::__entropy!(stringify!($e), 2), $e) };
 }
 #[doc(hidden)]
 #[macro_export]


### PR DESCRIPTION
Obfstr uses the original string as a source of entropy per invocation.
A typo made it always use `$ e` instead of the original string.

Introduce internal __entropy to avoid unnecessary const items.